### PR TITLE
elements were not removed from radixtree when peer is closed

### DIFF
--- a/src/jet/daemon.lua
+++ b/src/jet/daemon.lua
@@ -569,6 +569,7 @@ local create_daemon = function(options)
           if element.peer == peer then
             publish(path,'remove',element.value,element)
             elements[path] = nil
+            radixtree.remove(path)
           end
         end
         flush_peers()


### PR DESCRIPTION
Leads to inconsistent element lists. fetch may not be possible anymore.
