### PR TITLE
Use LuaRocks 2.1.1 in Travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,26 @@
 language: erlang
 
 env:
+  global:
+    - LUAROCKS_BASE=luarocks-2.1.1
+    - LUA=lua5.1
+    - LUA_DEV=liblua5.1-dev
+    - LUA_VER=5.1
+    - LUA_SFX=5.1
+    - LUA_INCDIR=/usr/include/lua5.1
 
 install:
   - sudo apt-get install libev-dev
   - sudo apt-get install luajit
-  - sudo apt-get install luarocks
+  - sudo apt-get install $LUA
+  - sudo apt-get install $LUA_DEV
+  # Install a recent luarocks release
+  - wget http://luarocks.org/releases/$LUAROCKS_BASE.tar.gz
+  - tar zxvpf $LUAROCKS_BASE.tar.gz
+  - pushd $LUAROCKS_BASE
+  - ./configure --lua-version=$LUA_VER --lua-suffix=$LUA_SFX --with-lua-include="$LUA_INCDIR"
+  - make build && sudo make install
+  - popd
   - sudo luarocks install busted 1.11.1-1
   - sudo luarocks make rockspecs/lua-jet-scm-1.rockspec
 


### PR DESCRIPTION
Uses a specific LuaRocks version in order to properly install rocks which points to git tags.
