### PR TITLE
Fixes link to documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Watch Your Jet Bus on [Your local Radar](http://localhost:8080).
 
 # Doc
 
-For general information, visit the [Jet Homepage](http://lipp.github.io/jet). Look at the [API.md](https://github.com/lipp/lua-jet/blob/master/API.md), the [examples](https://github.com/lipp/lua-jet/tree/master/examples) or the [busted](https://github.com/lipp/busted/tree/add-finally) test [spec files](https://github.com/lipp/lua-jet/tree/master/spec).
+For general information, visit the [Jet Homepage](http://jetbus.io). Look at the [API.md](https://github.com/lipp/lua-jet/blob/master/API.md), the [examples](https://github.com/lipp/lua-jet/tree/master/examples) or the [busted](https://github.com/lipp/busted/tree/add-finally) test [spec files](https://github.com/lipp/lua-jet/tree/master/spec).
 
 # Tests
 


### PR DESCRIPTION
The site the link is pointing to now is missing the css stylesheets. I think the correct link is to jetbus.io ?
