### PR TITLE
alias value_as_result to valueAsResult

### DIFF
--- a/spec/peer_spec.lua
+++ b/spec/peer_spec.lua
@@ -245,6 +245,32 @@ create_peer_tests = function(config)
               })
             end)
 
+          it('peer can set value and value_as_result aliases valueAsResult',function(done)
+              peer:state({
+                  path = 'adjusting_state',
+                  value = {
+                    x = 3
+                  },
+                  set = function(newval)
+                    local t = {}
+                    t.x = math.floor(newval.x)
+                    -- return the "real" adjusted value
+                    return t
+                  end
+              })
+              local new_val = 716.44
+              peer:set('adjusting_state',{x=new_val},{
+                  value_as_result = true,
+                  success = async(function(result)
+                      assert.is_same(result,{x=math.floor(new_val)})
+                      done()
+                    end),
+                  error = async(function(err)
+                      assert.is_falsy(err)
+                    end)
+              })
+            end)
+
           it('peer can set value and adjustments are not visible in result if valueAsResult is undefined',function(done)
               peer:state({
                   path = 'adjusting_state2',

--- a/src/jet/peer.lua
+++ b/src/jet/peer.lua
@@ -352,6 +352,10 @@ local new = function(config)
         path = path,
         value = value
       }
+      if callbacks and not callbacks.valueAsResult then
+        callbacks.valueAsResult = callbacks.value_as_result
+        callbacks.value_as_result = nil
+      end
       service('set',params,nil,callbacks)
     end
 


### PR DESCRIPTION
support both camelcase and underscoring
